### PR TITLE
Fix deserialization of user dict saved with msgpack

### DIFF
--- a/spacy_pkuseg/__init__.py
+++ b/spacy_pkuseg/__init__.py
@@ -54,7 +54,6 @@ class Preprocesser:
                     w = w_t.strip()
                     t = ''
                 else:
-                    assert isinstance(w_t, tuple)
                     assert len(w_t)==2
                     w, t = map(lambda x:x.strip(), w_t)
                 self.insert(w, t)


### PR DESCRIPTION
If the user dict is serialized with msgpack rather than pickle, it is deserialized as lists instead of tuples, which does not work with this specific type check.