### PR TITLE
Update version pin to allow NumPy 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "setuptools",
-    "numpy>=2.0.0,<3.0.0; python_version < '3.9'",
-    "numpy>=2.0.0,<3.0.0; python_version >= '3.9'",
+    "numpy>=2.0.0,<3.0.0",
     "cython>=0.25",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-numpy>=2.0.0,<3.0.0; python_version < '3.9'
-numpy>=2.0.0,<3.0.0; python_version >= '3.9'
+numpy>=2.0.0,<3.0.0
 srsly>=2.3.0,<3.0.0
 cython>=0.25
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,9 +18,6 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Programming Language :: Cython
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -35,8 +32,7 @@ setup_requires =
     cython>=0.25
     numpy>=2.0.0,<3.0.0
 install_requires =
-    numpy>=2.0.0,<3.0.0; python_version < '3.9'
-    numpy>=2.0.0,<3.0.0; python_version >= '3.9'
+    numpy>=1.19.0,<3.0.0
     srsly>=2.3.0,<3.0.0
 
 [bdist_wheel]


### PR DESCRIPTION
This PR updates the version pin to allow `spacy-pkuseg` to be used with `NumPy` 1.x, which would also ease compatibility issues with other 3rd-party packages requiring `NumPy` 1.x.

When building against NumPy 2.x, it is tested locally that `spacy-pkuseg` can be used with both `NumPy` 1 and 2.

Also some clean-ups of support for Python <= 3.9.